### PR TITLE
Changed the controller creation using the resolver

### DIFF
--- a/_posts/2012-08-02-rest-apis-with-symfony2-the-right-way.markdown
+++ b/_posts/2012-08-02-rest-apis-with-symfony2-the-right-way.markdown
@@ -525,6 +525,7 @@ all for the listener. Here is the code:
 namespace Acme\DemoBundle\EventListener;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;


### PR DESCRIPTION
This allows supporting any controller (class name, bundle alias,
service, function name, Silex closure...).
It also fixes the handling of parameters as the controller is not
called using the order of the parameters in the matched route but
based on the name of the arguments, which was not the case in your
implementation.
