### PR TITLE
Updated the form error message

### DIFF
--- a/_posts/2012-08-02-rest-apis-with-symfony2-the-right-way.markdown
+++ b/_posts/2012-08-02-rest-apis-with-symfony2-the-right-way.markdown
@@ -310,11 +310,15 @@ example, you could get the following error response:
 
 {% highlight javascript %}
 {
-  "children": {
-    "username": {
-      "errors": [
-        "This value should not be blank."
-      ]
+  "code": 400,
+  "message": "Validation Failed";
+  "errors": {
+    "children": {
+      "username": {
+        "errors": [
+          "This value should not be blank."
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Since you wrote the post, FOSRestBundle default error messages for invalid forms has changed.
