### PR TITLE
Update 2012-08-02-rest-apis-with-symfony2-the-right-way.markdown

### DIFF
--- a/_posts/2012-08-02-rest-apis-with-symfony2-the-right-way.markdown
+++ b/_posts/2012-08-02-rest-apis-with-symfony2-the-right-way.markdown
@@ -571,6 +571,9 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 class LinkRequestListener
 {
@@ -641,7 +644,12 @@ class LinkRequestListener
             if (false === $controller = $this->resolver->getController($stubRequest)) {
                 continue;
             }
-
+            
+            // Make sure @ParamConverter and friends are handled
+            $subEvent = new FilterControllerEvent($event->getKernel(), $controller, $stubRequest, HttpKernelInterface::MASTER_REQUEST);
+            $event->getDispatcher()->dispatch(KernelEvents::CONTROLLER, $subEvent);
+            $controller = $subEvent->getController();
+            
             $arguments = $this->resolver->getArguments($stubRequest, $controller);
 
             try {


### PR DESCRIPTION
Dispatch a `kernel.controller` event to make sure annotations behave in the right way.

`@ParamConverter` annotations are only handled when this event is dispatched. Else those parameters are not filled in properly, and seemingly random errors start popping up.

I noticed this 'bug' when using your nice LinkRequestListener class for my project. This post has been very helpful for me, so I thought to give you something in return :smile: 
