### PR TITLE
Removed extra scrollbars on code snippets

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -163,7 +163,7 @@ a.link.current {
     font-size: 90%;
     line-height: 1.3em;
     background-color: #000;
-    overflow-x: scroll;
+    overflow-x: auto;
 }
 
 pre {


### PR DESCRIPTION
This avoids having 2 useless scrollbars on each code snippet when they don't need scrolling
