### PR TITLE
Ampersand causes invalid xml and breaks rss-feed

### DIFF
--- a/_posts/2014-12-17-elasticsearch-logstash-kibana-with-docker.markdown
+++ b/_posts/2014-12-17-elasticsearch-logstash-kibana-with-docker.markdown
@@ -4,7 +4,7 @@ location: Clermont-Fd Area, France
 tldr: false
 audio: false
 tags: [ Docker ]
-title: "Elasticsearch, Logstash & Kibana with Docker"
+title: "Elasticsearch, Logstash &amp; Kibana with Docker"
 ---
 
 Yesterday, I gave a talk on [how I use **Docker** to deploy


### PR DESCRIPTION
The ampersand in the title causes an error when the article is loaded for the feedburner feed.

Another possibility would be to replace it with "and" :)
