### PR TITLE
Fix the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
-
-before_script:
-  - gem install public_suffix -v '1.5.1
+rvm: 2.1
+cache: bundler
 
 script: "bundle exec jekyll build"

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ safe:      true
 permalink: pretty
 highlighter: pygments
 markdown:  redcarpet
-exclude:   [ README.md, Gemfile ]
+exclude:   [ README.md, Gemfile, vendor ]
 
 site:
     title:  William DURAND


### PR DESCRIPTION
Travis defaults to Ruby 1.9.3, but the github-pages gem requires to use Ruby 2.