### PR TITLE
Update 2014-02-14-please-do-not-patch-like-an-idiot.markdown

### DIFF
--- a/_posts/2014-02-14-please-do-not-patch-like-an-idiot.markdown
+++ b/_posts/2014-02-14-please-do-not-patch-like-an-idiot.markdown
@@ -77,7 +77,7 @@ The entire set of changes must be applied **atomically**, and the API must never
 provide a partially modified representation by the way. It is worth mentioning
 that the request entity to `PATCH` is of a **different content-type** than the
 resource that is being modified.  You have to use a media type that defines
-semantics for PATCH, otherwise you loose the advantage of this method, and you
+semantics for PATCH, otherwise you lose the advantage of this method, and you
 can use either `PUT` or `POST`. From the RFC:
 
 > The difference between the PUT and PATCH requests is reflected in the way the


### PR DESCRIPTION
Typo (loose instead of lose)